### PR TITLE
add support for force loading themes

### DIFF
--- a/remember-theme.el
+++ b/remember-theme.el
@@ -57,6 +57,8 @@
 
 ;;; Code:
 
+(defvar remember-theme-load-force nil)
+
 ;;;###autoload
 (defun remember-theme-save ()
   "Creates (or replaces) ~/.emacs-theme, and stores the name of
@@ -81,7 +83,7 @@ creating or editing this file is not supported"
       (load-theme (intern (car (nreverse (with-temp-buffer
                                            (insert-file-contents "~/.emacs-theme")
                                            (split-string
-                                            (buffer-string)))))))))
+                                            (buffer-string)))))) remember-theme-load-force)))
 
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
some times people stores init.el under version control and do not want emacs to write any generated code to this file. That's why I added variable remember-theme-load-force, which passed to load-theme function. If it's true, theme is loading without asking and without modifiing init.el.
